### PR TITLE
Add redirect for Kollokvier

### DIFF
--- a/src/sites.json
+++ b/src/sites.json
@@ -85,6 +85,11 @@
     "image": "ababart_mikrofon.svg"
   },
   {
+    "name": "Kollokvier",
+    "url": "https://aba.wtf/kollokvie",
+    "image": ""
+  },
+  {
     "name": "Ababart",
     "url": "https://aba.wtf",
     "image": "ababart_abawtf.svg"


### PR DESCRIPTION
Added a redirect for aba.wtf/kollokvie, as per requested by Sagmo.

Currently no logo made